### PR TITLE
fixed data race and log message

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -413,7 +413,7 @@ func (c *Conn) resendZkAuth() error {
 
 	if len(c.creds) > 0 {
 		c.logger.Printf("Re-submitting %d credentials id=0x%x after reconnect",
-			c.SessionID(), len(c.creds))
+			len(c.creds), c.SessionID())
 	}
 	for _, cred := range c.creds {
 		resChan, err := c.sendRequest(


### PR DESCRIPTION
fixed incorrect order of the args in `Re-submitting...` log message.

Example of the message before the fix:
`I1102 11:30:36.309285 65018 conn.go:416] Re-submitting 72453284692679946 credentials id=0x1 after reconnect`